### PR TITLE
oc-cluster-up job to spawn Openshift cluster

### DIFF
--- a/playbooks/oc-cluster-up.yaml
+++ b/playbooks/oc-cluster-up.yaml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - oc-cluster-up

--- a/roles/oc-cluster-up/README.md
+++ b/roles/oc-cluster-up/README.md
@@ -1,0 +1,2 @@
+`oc-cluster-up` role for `oc-cluster-up` job which installs docker
+and installs and starts Openshift v3 cluster with `oc cluster up`.

--- a/roles/oc-cluster-up/tasks/main.yml
+++ b/roles/oc-cluster-up/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+- name: Install docker and oc cluster up Openshift v3
+  hosts: all
+  tasks:
+    - name: Setup Docker CE repo
+      get_url:
+        url: https://download.docker.com/linux/fedora/docker-ce.repo
+        dest: /etc/yum.repos.d/docker-ce.repo
+        mode: 0644
+      become: true
+    - name: Install Docker CE
+      dnf:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+        state: present
+      become: true
+    - name: Put SELinux in permissive mode, logging actions that would be blocked.
+      selinux:
+        policy: targeted
+        state: permissive
+      become: true
+    - name: Make sure docker is running
+      systemd:
+        name: docker
+        state: started
+      become: true
+    - name: Create docker deamon config
+      file:
+        path: /etc/docker/daemon.json
+        state: touch
+      become: true
+    - name: Add OpenShift insecure registry into docker deamon config
+      copy:
+        content: |
+          {"insecure-registries" : [ "172.30.0.0/16" ]}
+        dest: /etc/docker/daemon.json
+      become: true
+    - name: Restart docker because config has changed
+      systemd:
+        state: restarted
+        daemon_reload: yes
+        name: docker
+      become: true
+    - name: Install OpenShift server
+      dnf:
+        name:
+          - origin
+        state: present
+      become: true
+    - name: Start Openshift cluster
+      command: oc cluster up --base-dir=/tmp --enable="-centos-imagestreams,-sample-templates,persistent-volumes,registry,router,-web-console"
+      environment:
+        PATH: "{{ ansible_env.PATH }}:/usr/local/bin"
+        DOCKER_CONFIG: "/etc/docker/daemon.json"
+      become: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -41,3 +41,15 @@
     description: Install and run pre-commit
     parent: base
     run: playbooks/pre-commit.yaml
+
+- job:
+    name: oc-cluster-up
+    parent: base
+    attempts: 1
+    description: Deploy Openshift v3 cluster
+    pre-run:
+      - playbooks/oc-cluster-up.yaml
+    nodeset:
+      nodes:
+        - name: test-node
+          label: cloud-fedora-30


### PR DESCRIPTION
To be used in [sandcastle](https://github.com/packit/sandcastle/blob/master/files/install-openshift.yaml) and [packit-service](https://github.com/packit/packit-service/blob/master/files/install-openshift.yaml).