### PR TITLE
[base job] define project_dir 

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -11,7 +11,7 @@
     extra-vars:
       zuul_use_fetch_output: true
     timeout: 1800
-    attempts: 3
+    attempts: 2
     secrets:
       - site_sflogs
     nodeset:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -10,6 +10,7 @@
       - zuul: zuul/zuul-jobs
     extra-vars:
       zuul_use_fetch_output: true
+      project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
     timeout: 1800
     attempts: 2
     secrets:


### PR DESCRIPTION
I'm wondering why Zuul already hasn't some variable like this.
We define it ourselves in
https://github.com/packit/packit/blob/master/files/tasks/zuul-project-setup.yaml#L5
https://github.com/packit/ogr/blob/master/files/tasks/zuul-project-setup.yaml#L5
https://github.com/packit/dashboard/blob/master/files/tasks/zuul-project-setup.yaml#L5
https://github.com/packit/packit-service/blob/master/files/tasks/zuul-project-setup.yaml#L5
https://github.com/packit/requre/blob/master/files/tasks/zuul-project-setup.yaml#L5
https://github.com/packit/sandcastle/blob/master/files/tasks/zuul-project-setup.yaml#L5