### PR TITLE
Update pre-commit configuration for prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@
 # pre-commit install
 
 repos:
-  - repo: https://github.com/prettier/prettier
-    rev: 2.0.5
+  - repo: https://github.com/prettier/pre-commit
+    rev: v2.1.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
In order to solve this installation issue:

https://github.com/prettier/prettier/issues/9459

It seems that prettier is moving the pre-commit parts in a separate
repository.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>