### PR TITLE
Switch pre-commit to run manual stage

### DIFF
--- a/roles/pre-commit/tasks/main.yml
+++ b/roles/pre-commit/tasks/main.yml
@@ -9,12 +9,7 @@
       - pre-commit
   become: true
 
-- name: Run 'pre-commit install' to set up git hook scripts
-  command: pre-commit install
-  args:
-    chdir: "{{ zuul.project.src_dir }}"
-
 - name: Run pre-commit
-  command: pre-commit run --all-files
+  command: pre-commit run --all-files --hook-stage manual
   args:
     chdir: "{{ zuul.project.src_dir }}"


### PR DESCRIPTION
Allows us to switch off inconvenient hooks in pre-commit CI, such as
requre cleanup (time outs) or rebase check (no internet there (yet?)),
but let us run them in Zuul or locally.

Should be merged before https://github.com/packit/ogr/pull/499, since the rebase + requre is not checked in it in zuul.

- [ ] Also I noticed this task: `Run 'pre-commit install' to set up git hook scripts`
     I am not sure about the reason? How are we using git hooks in zuul?

Signed-off-by: Matej Focko <mfocko@redhat.com>