### PR TITLE
[oc-cluster-up job] use parent job node

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -50,7 +50,3 @@
     description: Deploy Openshift v3 cluster
     pre-run:
       - playbooks/oc-cluster-up.yaml
-    nodeset:
-      nodes:
-        - name: test-node
-          label: cloud-fedora-30


### PR DESCRIPTION
i.e. fedora-32 instead of fedora-30

Docker v20.10 with cgroups v2 support has been released so we no longer have to stay with fedora-30.