### PR TITLE
Update status line for gate trigger/require

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -60,7 +60,7 @@
             type: approved
         # Require label
         label: mergeit
-        status: "softwarefactory-project-zuul\\[bot\\]:packit-service/check:success"
+        status: "softwarefactory-project-zuul:packit-service/check:success"
         open: True
         current-patchset: True
     trigger:
@@ -79,7 +79,7 @@
           state: request_changes
         - event: pull_request
           action: status
-          status: "softwarefactory-project-zuul\\[bot\\]:packit-service/check:success"
+          status: "softwarefactory-project-zuul:packit-service/check:success"
         - event: pull_request
           action: labeled
           label:


### PR DESCRIPTION
2021-03-16 08:31:10,308 DEBUG zuul.Pipeline.packit-service.gate: [e: f4e4ffe0-8631-11eb-8832-356a35a07efd] Change <Change 0x7ff22cfc44a8 packit/packit-service 1020,fb1b2831371416cbdf85c5349438de2f36111e65> does not match pipeline requirement <GithubRefFilter connection_name: github.com statuses: softwarefactory-project-zuul\[bot\]:packit-service/check:success required-reviews: [{'permission': 'write', 'type': 'approved'}] open: True current-patchset: True labels: ['mergeit']> because RequiredStatuses ['softwarefactory-project-zuul\\[bot\\]:packit-service/check:success'] does not match ['pre-commit-ci:pre-commit.ci - pr:success', 'softwarefactory-project-zuul:packit-service/check:success']