### PR TITLE
Tweak the pull_request.status trigger for the gating pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -81,6 +81,9 @@
           action: status
           status: "softwarefactory-project-zuul:packit-service/check:success"
         - event: pull_request
+          action: status
+          status: "softwarefactory-project-zuul\\[bot\\]:packit-service/check:success"
+        - event: pull_request
           action: labeled
           label:
             - mergeit


### PR DESCRIPTION
It seems that '[bot]' shouldn't have been removed from the trigger
status. Put it back to check if gating pipeline are triggered by check
pipelines that finish successfully.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>