### PR TITLE
Don't prefix project_dir with {{ ansible_user_dir }}/

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -10,7 +10,7 @@
       - zuul: zuul/zuul-jobs
     extra-vars:
       zuul_use_fetch_output: true
-      project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+      project_dir: "{{ zuul.project.src_dir }}"
     timeout: 1800
     attempts: 2
     secrets:


### PR DESCRIPTION
as suggested by @morucci in https://github.com/packit/packit-service/pull/1137