### PR TITLE
Don't redefine project_dir at all

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -10,7 +10,6 @@
       - zuul: zuul/zuul-jobs
     extra-vars:
       zuul_use_fetch_output: true
-      project_dir: "{{ zuul.project.src_dir }}"
     timeout: 1800
     attempts: 2
     secrets:


### PR DESCRIPTION
from some point it doesn't work.
Let's define it in individual jobs to see what's going on here.