### PR TITLE
[base job] fedora-33 -> fedora-34

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -17,7 +17,7 @@
     nodeset:
       nodes:
         - name: container
-          label: cloud-fedora-33
+          label: cloud-fedora-34
 
 - job:
     name: linters


### PR DESCRIPTION
packit-service reverse dependency tests in packit fail with `python-gitlab 2.10.1 has requirement requests>=2.25.0, but you have requests 2.24.0.`, with f34 the version of python-requests should be 2.25.1