### PR TITLE
Revert "Merge pull request #63 from jpopelka/pre-commit"

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,7 +7,3 @@ skip_list:
   - missing-import  # in playbooks/base/ we import roles not from this repo
   - role-name  # we're not going to publish the roles
   - unnamed-task  # pretty strict
-
-mock_modules:
-  # Silence for F35, move to ansible.posix.selinux since F36
-  - selinux

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,11 @@
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.2
+    rev: v2.5.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.1.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -17,7 +17,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/willthames/ansible-lint.git
-    rev: v6.0.2
+    rev: v5.3.2
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$

--- a/roles/linters/tasks/lint_ansible-lint.yaml
+++ b/roles/linters/tasks/lint_ansible-lint.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Run ansible-lint
-  ansible.builtin.shell: "ansible-lint -p --nocolor {{ ansible_lint_roles_dir }}/*"
+  shell: "ansible-lint -p --nocolor {{ ansible_lint_roles_dir }}/*"
   register: _ansible_lint
   ignore_errors: true
   changed_when: false
@@ -11,7 +11,7 @@
   when: ansible_lint_roles_dir
 
 - name: Set linter failure to true
-  ansible.builtin.set_fact:
+  set_fact:
     linter_failure: true
   when:
     - ansible_lint_roles_dir

--- a/roles/linters/tasks/lint_bashate.yaml
+++ b/roles/linters/tasks/lint_bashate.yaml
@@ -1,6 +1,6 @@
 ---
 - name: "Run bashate"
-  ansible.builtin.shell: find * -name "*.sh" | xargs --no-run-if-empty bashate
+  shell: find * -name "*.sh" | xargs --no-run-if-empty bashate
   register: _bashate
   ignore_errors: true
   changed_when: false
@@ -10,6 +10,6 @@
     chdir: "{{ zuul.project.src_dir }}"
 
 - name: Set linter failure to true
-  ansible.builtin.set_fact:
+  set_fact:
     linter_failure: true
   when: _bashate.rc

--- a/roles/linters/tasks/lint_doc8.yaml
+++ b/roles/linters/tasks/lint_doc8.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Run doc8
-  ansible.builtin.shell: >
+  shell: >
     find * -name "*.rst" | xargs --no-run-if-empty doc8
   register: _doc8
   ignore_errors: true
@@ -11,6 +11,6 @@
     chdir: "{{ zuul.project.src_dir }}"
 
 - name: Set linter failure to true
-  ansible.builtin.set_fact:
+  set_fact:
     linter_failure: true
   when: _doc8.rc

--- a/roles/linters/tasks/lint_flake8.yaml
+++ b/roles/linters/tasks/lint_flake8.yaml
@@ -1,6 +1,6 @@
 ---
 - name: "Run flake8"
-  ansible.builtin.shell: find * -name "*.py" | xargs --no-run-if-empty flake8
+  shell: find * -name "*.py" | xargs --no-run-if-empty flake8
   register: _flake8
   ignore_errors: true
   changed_when: false
@@ -10,6 +10,6 @@
     chdir: "{{ zuul.project.src_dir }}"
 
 - name: Set linter failure to true
-  ansible.builtin.set_fact:
+  set_fact:
     linter_failure: true
   when: _flake8.rc

--- a/roles/linters/tasks/lint_golint.yaml
+++ b/roles/linters/tasks/lint_golint.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Run golint
-  ansible.builtin.shell: >
+  shell: >
     find * -name "*.go" | xargs --no-run-if-empty golint -set_exit_status
   register: _golint
   ignore_errors: true
@@ -11,6 +11,6 @@
     chdir: "{{ zuul.project.src_dir }}"
 
 - name: Set linter failure to true
-  ansible.builtin.set_fact:
+  set_fact:
     linter_failure: true
   when: _golint.rc

--- a/roles/linters/tasks/lint_yamllint.yaml
+++ b/roles/linters/tasks/lint_yamllint.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Run yamllint
-  ansible.builtin.shell: >
+  shell: >
     find * -name "*.yml" -or -name "*.yaml" |
         xargs --no-run-if-empty yamllint -d relaxed
   register: _yamllint
@@ -12,6 +12,6 @@
     chdir: "{{ zuul.project.src_dir }}"
 
 - name: Set linter failure to true
-  ansible.builtin.set_fact:
+  set_fact:
     linter_failure: true
   when: _yamllint.rc

--- a/roles/linters/tasks/main.yaml
+++ b/roles/linters/tasks/main.yaml
@@ -1,12 +1,12 @@
 ---
 - name: Set linter failure to false
-  ansible.builtin.set_fact:
+  set_fact:
     linter_failure: false
 
 - include: "lint_{{ item }}.yaml"
   loop: "{{ linters }}"
 
 - name: Fail if one linter failed
-  ansible.builtin.fail:
+  fail:
     msg: "One or more file(s) failed lint checks"
   when: linter_failure

--- a/roles/oc-cluster-up/tasks/main.yml
+++ b/roles/oc-cluster-up/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 - name: Install epel-release
-  ansible.builtin.package:
+  package:
     name:
       - epel-release
   become: true
   when: ansible_distribution == 'CentOS'
 - name: Setup Docker CE repo
-  ansible.builtin.get_url:
+  get_url:
     url: https://download.docker.com/linux/centos/docker-ce.repo
     dest: /etc/yum.repos.d/docker-ce.repo
     mode: 0644
   become: true
 - name: Install Docker CE
-  ansible.builtin.package:
+  package:
     name:
       - docker-ce
       - docker-ce-cli
@@ -21,7 +21,7 @@
     state: present
   become: true
 - name: Install Openshift Origin
-  ansible.builtin.package:
+  package:
     name:
       - origin
     state: present
@@ -32,31 +32,31 @@
     state: permissive
   become: true
 - name: Make sure docker is running
-  ansible.builtin.systemd:
+  systemd:
     name: docker
     state: started
   become: true
 - name: Create docker deamon config
-  ansible.builtin.file:
+  file:
     path: /etc/docker/daemon.json
     state: touch
     mode: 0644
   become: true
 - name: Add OpenShift insecure registry into docker deamon config
-  ansible.builtin.copy:
+  copy:
     content: |
       {"insecure-registries" : [ "172.30.0.0/16" ]}
     dest: /etc/docker/daemon.json
     mode: 0644
   become: true
 - name: Restart docker because config has changed
-  ansible.builtin.systemd:
+  systemd:
     state: restarted
     daemon_reload: true
     name: docker
   become: true
 - name: Start Openshift cluster
-  ansible.builtin.command: oc cluster up --base-dir=/tmp --enable="-centos-imagestreams,-sample-templates,persistent-volumes,registry,router,-web-console"
+  command: oc cluster up --base-dir=/tmp --enable="-centos-imagestreams,-sample-templates,persistent-volumes,registry,router,-web-console"
   environment:
     PATH: "{{ ansible_env.PATH }}:/usr/local/bin"
     DOCKER_CONFIG: "/etc/docker/daemon.json"

--- a/roles/pre-commit/tasks/main.yml
+++ b/roles/pre-commit/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install packages
-  ansible.builtin.dnf:
+  dnf:
     name:
       - git-core
       - python36
@@ -10,7 +10,7 @@
   become: true
 
 - name: Run pre-commit
-  ansible.builtin.command: pre-commit run --all-files --hook-stage manual
+  command: pre-commit run --all-files --hook-stage manual
   args:
     chdir: "{{ zuul.project.src_dir }}"
   register: pc_result


### PR DESCRIPTION
This reverts commit 857f79554d471b64b4de6ce36df4f7b46a5334d1, reversing
changes made to 5ab2775556018fca67e69ae1848dd3c526c04870.

Zuul's ansible wasn't ready for these changes. We are reverting before they upgrade.

```
17:36 <mhu> are these changes compatible with ansible 2.9?
17:40 <mhu> ttomecek (IRC): I think Zuul uses a slightly modified version of ansible so I'm not sure the changes in the commit you linked are compatible with this
17:41 <mhu> could you possibly revert that change and retry?
17:43 <tdecacqu[m]> ttomecek (IRC): this is a zuul bug fixed by https://review.opendev.org/c/zuul/zuul/+/835662 . It should be fixed tomorrow when we upgrade zuul tomorrow, until then you can fix the issue by using the regular command module name
```

(tomorrow = May 4th)