### PR TITLE
run pre-commit hooks verbosely

### DIFF
--- a/roles/pre-commit/tasks/main.yml
+++ b/roles/pre-commit/tasks/main.yml
@@ -10,7 +10,7 @@
   become: true
 
 - name: Run pre-commit
-  ansible.builtin.command: pre-commit run --all-files --hook-stage manual
+  ansible.builtin.command: pre-commit run --all-files --hook-stage manual --verbose
   args:
     chdir: "{{ zuul.project.src_dir }}"
   register: pc_result


### PR DESCRIPTION
I need this for the thoth pre-commit hook so it can print a link to thoth's web UI so everyone can easily access an analysis.

It's also useful to see "info" output from hooks instead of just dots & Passed.

Also the output is not terribly verbose, example:
```
pyupgrade................................................................Passed
- hook id: pyupgrade
- duration: 0.22s

WARNING: pyupgrade will default to --py3-plus in 3.x
WARNING: pyupgrade will default to --py3-plus in 3.x
WARNING: pyupgrade will default to --py3-plus in 3.x
WARNING: pyupgrade will default to --py3-plus in 3.x
WARNING: pyupgrade will default to --py3-plus in 3.x
WARNING: pyupgrade will default to --py3-plus in 3.x
WARNING: pyupgrade will default to --py3-plus in 3.x
WARNING: pyupgrade will default to --py3-plus in 3.x

black....................................................................Passed
- hook id: black
- duration: 0.17s

All done! ✨ 🍰 ✨
90 files left unchanged.

prettier.................................................................Failed
- hook id: prettier
- duration: 1.1s
- files were modified by this hook

.pre-commit-config.yaml

check docstring is first.................................................Passed
- hook id: check-docstring-first
- duration: 0.12s
check for merge conflicts................................................Passed
- hook id: check-merge-conflict
- duration: 0.07s
check for broken symlinks............................(no files to check)Skipped
- hook id: check-symlinks
mypy.....................................................................Passed
- hook id: mypy
- duration: 2.08s

Success: no issues found in 90 source files
```