### PR TITLE
update environment from f35 to ~~f36~~ f37

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -17,7 +17,7 @@
     nodeset:
       nodes:
         - name: container
-          label: cloud-fedora-35
+          label: cloud-fedora-37
 
 - job:
     name: linters


### PR DESCRIPTION
We are seeing 404s with EOLd F35:

```
12:09 <MajaMassarini[m]> Am I the only one experiencing problems with Zuul? The `github.com/packit/packit-service-zuul/playbooks/pre-commit.yaml` playbook is failing with this error: ```The Failed to download packages: Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=fedora-35&arch=x86_64 (IP: 152.19.134.198)``` but if I understand it correctly are not us asking for a fedora 35 mirror, I think it is Zuul. What do you think?
```