### PR TITLE
oc-cluster-up: create /etc/docker/daemon.json right away

### DIFF
--- a/roles/oc-cluster-up/tasks/main.yml
+++ b/roles/oc-cluster-up/tasks/main.yml
@@ -4,13 +4,14 @@
     name:
       - epel-release
   become: true
-  when: ansible_distribution == 'CentOS'
+
 - name: Setup Docker CE repo
   ansible.builtin.get_url:
     url: https://download.docker.com/linux/centos/docker-ce.repo
     dest: /etc/yum.repos.d/docker-ce.repo
     mode: 0644
   become: true
+
 - name: Install Docker CE
   ansible.builtin.package:
     name:
@@ -20,41 +21,36 @@
       - centos-release-openshift-origin
     state: present
   become: true
+
 - name: Install Openshift Origin
   ansible.builtin.package:
     name:
       - origin
     state: present
   become: true
+
 - name: Put SELinux in permissive mode, logging actions that would be blocked.
   selinux:
     policy: targeted
     state: permissive
   become: true
+
+- name: Add OpenShift insecure registry into docker deamon config
+  ansible.builtin.lineinfile:
+    path: /etc/docker/daemon.json
+    search_string: insecure-registries
+    line: |
+      {"insecure-registries" : [ "172.30.0.0/16" ]}
+    create: true
+    mode: 0644
+  become: true
+
 - name: Make sure docker is running
   ansible.builtin.systemd:
     name: docker
     state: started
   become: true
-- name: Create docker deamon config
-  ansible.builtin.file:
-    path: /etc/docker/daemon.json
-    state: touch
-    mode: 0644
-  become: true
-- name: Add OpenShift insecure registry into docker deamon config
-  ansible.builtin.copy:
-    content: |
-      {"insecure-registries" : [ "172.30.0.0/16" ]}
-    dest: /etc/docker/daemon.json
-    mode: 0644
-  become: true
-- name: Restart docker because config has changed
-  ansible.builtin.systemd:
-    state: restarted
-    daemon_reload: true
-    name: docker
-  become: true
+
 - name: Start Openshift cluster
   ansible.builtin.command: oc cluster up --base-dir=/tmp --enable="-centos-imagestreams,-sample-templates,persistent-volumes,registry,router,-web-console"
   environment:


### PR DESCRIPTION
Since docker-ce v23 appeared in the [docker rpm repo](https://download.docker.com/linux/centos/7/x86_64/stable/Packages/) our `oc-cluster-up` role started to [fail](https://softwarefactory-project.io/zuul/t/packit-service/build/c7637c41da424d4486cc1ba3b33181a6/console) with
`Error, could not touch target: [Errno 2] No such file or directory: '/etc/docker/daemon.json'`

Previously we
1. started docker service
2. touched `/etc/docker/daemon.json`
3. added `insecure_registry` into it
4. restarted the docker service

I don't remember why there was the 1. step, probably because it created the `/etc/docker/`.
With docker v23 the 2. step fails probably because the `/etc/docker/` is not created in the 1. step.
So let's create it right away and start the docker service afterward.

Now the steps are:
1. Add insecure_registry to `/etc/docker/daemon.json` (create if not exist)
3. start docker service

Unlike the `file` module, the `lineinfile` module doesn't mind if the parent directory doesn't exist, it creates it as well.