### PR TITLE
fix(github): allow running on PRs in merge queue

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -15,6 +15,8 @@
         - event: pull_request
           action: comment
           comment: (?i)^\s*recheck\s*$
+        - event: push
+          ref: ^refs/heads/gh-readonly-queue/.*$
     start:
       github.com:
         status: "pending"


### PR DESCRIPTION
When PRs are queued in merge queue, they are pushed to a separate branch on which GitHub expects required CI checks, therefore we need to enable Zuul on such branches, so that GitHub can correctly check the results of tests.

Suggested in: https://github.com/orgs/community/discussions/46757#discussioncomment-4959697 Docs: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-other-ci-providers

Signed-off-by: Matej Focko <mfocko@redhat.com>