### PR TITLE
Revert "Gitleaks pre-commit hook needs go"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/roles/pre_commit/tasks/main.yml
+++ b/roles/pre_commit/tasks/main.yml
@@ -3,7 +3,6 @@
   ansible.builtin.dnf:
     name:
       - git-core
-      - golang-bin
       - pre-commit
   become: true
 


### PR DESCRIPTION
This reverts commit 0120344dd9986f45ab967fc7d257dc505eebda27.

We'll not run the Gitleaks hook in Zuul after all. (The hook parses `git diff --staged` output, i.e. always passes in `pre-push`/`manual` stage.)