### PR TITLE
Move installing epel-release from oc_cluster_up role to base task

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -22,10 +22,8 @@
     - import_role: name=ensure-output-dirs
       when: ansible_user_dir is defined
 
-    - name: Enable EPEL9
-      ansible.builtin.dnf:
-        name:
-          - epel-release
-          - epel-next-release
+    - name: Install epel-release
+      ansible.builtin.package:
+        name: epel-release
         state: present
       become: true

--- a/roles/oc_cluster_up/tasks/main.yml
+++ b/roles/oc_cluster_up/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: Install epel-release
-  ansible.builtin.package:
-    name:
-      - epel-release
-  become: true
-
 - name: Setup Docker CE repo
   ansible.builtin.get_url:
     url: https://download.docker.com/linux/centos/docker-ce.repo


### PR DESCRIPTION
We now use only Centos 9 Stream and Centos 7 (for oc-cluster-up job) nodes and they both can install epel-release.

[package](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html) module is used because of yum on Centos 7