### PR TITLE
Install libatomic to the testing host

### DIFF
--- a/roles/pre_commit/tasks/main.yml
+++ b/roles/pre_commit/tasks/main.yml
@@ -4,6 +4,7 @@
     name:
       - git-core
       - pre-commit
+      - libatomic # required by prettier check with Node.js >= 25.0.0
   become: true
 
 - name: Run pre-commit


### PR DESCRIPTION
This is required to restore the Prettier check. Prettier uses Node.js, which as of version 25.0.0 switched its default compiler from GCC to Clang (see https://github.com/nodejs/node/commit/910c8796f97f8d12bf88957ec9ab268f4ec7d5a7). As a result, Node.js default builds now link against libatomic (https://github.com/nodejs/node/blob/f46d501b7f4c6a8b838f472693596044d14a566f/node.gyp#L527-L529).

Because libatomic is not installed by default, running the pre-commit check produces errors like this:

```
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/zuul-worker/.cache/pre-commit/repocrvp44ft/node_env-default/bin/node', '/home/zuul-worker/.cache/pre-commit/repocrvp44ft/node_env-default/bin/npm', 'install', '--include=dev', '--include=prod', '--ignore-prepublish', '--no-progress', '--no-save')
return code: 127
stdout: (none)
stderr:
    /home/zuul-worker/.cache/pre-commit/repocrvp44ft/node_env-default/bin/node: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```